### PR TITLE
Broker Address by environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,7 @@ services:
 
   random-sensors:
     build: .
+    environment:
+      - BROKER_ADDRESS=mqtt://mosca
     depends_on:
       - mosca

--- a/test-random-sensors.js
+++ b/test-random-sensors.js
@@ -1,7 +1,12 @@
 let sensor = require('.');
 
 // test
-const broker = 'mqtt://localhost'
+
+let broker = 'mqtt://localhost'
+
+if(typeof process.env.BROKER_ADDRESS !== "undefined"){
+  broker = process.env.BROKER_ADDRESS;
+}
 let sensors = [
   {
     name: 'temperatureChambre',


### PR DESCRIPTION
The broker address can now be changed with the environment variable. Now, we won't need to expose the broker port to localhost to make it accessible to random-sensor.